### PR TITLE
Extending the register form instead of base form

### DIFF
--- a/src/LdcUserProfile/Extensions/ZfcUser/ZfcUserFieldsetFactory.php
+++ b/src/LdcUserProfile/Extensions/ZfcUser/ZfcUserFieldsetFactory.php
@@ -22,7 +22,7 @@ class ZfcUserFieldsetFactory implements FactoryInterface
         $options = $serviceLocator->get('zfcuser_module_options');
         $entityClass = $options->getUserEntityClass();
 
-        $object = new ZfcUserFieldset(new ZfcUserForm($options));
+        $object = new ZfcUserFieldset(new ZfcUserForm(null, $options));
         $object->setHydrator($serviceLocator->get('zfcuser_user_hydrator'));
         $object->setObject(new $entityClass());
 

--- a/src/LdcUserProfile/Extensions/ZfcUser/ZfcUserForm.php
+++ b/src/LdcUserProfile/Extensions/ZfcUser/ZfcUserForm.php
@@ -9,17 +9,17 @@
 
 namespace LdcUserProfile\Extensions\ZfcUser;
 
-use ZfcUser\Form\Base;
+use ZfcUser\Form\Register;
 use ZfcUser\Options\RegistrationOptionsInterface;
 
-class ZfcUserForm extends Base
+class ZfcUserForm extends Register
 {
     protected $registrationOptions;
 
-    public function __construct(RegistrationOptionsInterface $registrationOptions)
+    public function __construct($name, RegistrationOptionsInterface $registrationOptions)
     {
         $this->setRegistrationOptions($registrationOptions);
-        parent::__construct();
+        parent::__construct($name, $registrationOptions);
     }
 
     /**


### PR DESCRIPTION
Extending the register form instead of base form, this ensures that disabled zfcuser elements are not shown on user profile form.
